### PR TITLE
Fix(CI): Skip Husky Install on Vercel Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
-    "prepare": "husky install",
+    "prepare": "test -n \"$CI\" || husky install",
     "test": "jest",
     "test:watch": "jest --watch"
   },


### PR DESCRIPTION
Resolves the build failure on Vercel by conditionally skipping the 'husky install' command in CI environments where devDependencies are not installed.