### PR TITLE
Fix(Lint): Disable no-explicit-any in Test

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -3,6 +3,7 @@ import Page from '../page';
 
 // Mock components that might cause issues in tests
 jest.mock('@/components/ui/button', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
 }));
 


### PR DESCRIPTION
This PR fixes the build failure by disabling the no-explicit-any ESLint rule for a specific line in a test file, allowing the CI pipeline to pass.